### PR TITLE
Change AR stage to be full screen modal

### DIFF
--- a/src/components/Alert/Alert.vue
+++ b/src/components/Alert/Alert.vue
@@ -1,0 +1,95 @@
+<template>
+  <div v-show="show" class="alert" :class="`alert--${variant}`">
+    <div class="alert__icon">
+      <i class="material-icons">{{ icon }}</i>
+    </div>
+
+    <div class="alert__text">
+      <slot>You have been alerted.</slot>
+    </div>
+
+    <button
+      v-if="dismissable"
+      class="alert__close-button"
+      @click="handleDismiss"
+    >
+      <i class="material-icons">close</i>
+      <span class="sr-only">Dismiss Alert</span>
+    </button>
+  </div>
+</template>
+<script setup>
+import { ref } from "vue";
+
+const props = defineProps({
+  icon: {
+    type: String,
+    default: "info",
+  },
+  dismissable: {
+    type: Boolean,
+    default: true,
+  },
+  variant: {
+    type: String,
+    default: "info",
+  },
+});
+
+const show = ref(true);
+function handleDismiss() {
+  if (!props.dismissable) return;
+  show.value = false;
+}
+</script>
+<style scoped>
+.alert {
+  padding: 1.2rem;
+  border-radius: 0.5rem;
+  margin: 1rem 0;
+  position: relative;
+  box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  color: #1d4ed8;
+  background: #eff6ff;
+}
+.alert__icon {
+  display: inline-flex;
+}
+.alert__text {
+  flex: 1;
+}
+
+.alert__close-button {
+  display: inline-flex;
+  background: none;
+  border: none;
+  justify-content: center;
+}
+
+.alert__close-button:hover {
+  background: rgb(0 0 0 / 5%);
+  border-radius: 0.5rem;
+}
+.alert__close-button:hover .material-icons {
+  color: var(--black);
+}
+
+.alert__icon {
+  color: #3b82f6;
+}
+
+.alert--warning {
+  background: #fefce8;
+  color: #a16207;
+}
+.alert--warning .alert__icon {
+  color: #eab308;
+}
+.alert--warning .alert__close-button {
+  color: #eab308;
+}
+</style>

--- a/src/components/Button/Button.vue
+++ b/src/components/Button/Button.vue
@@ -1,13 +1,13 @@
 <template>
-  <button class="button" :class="classMap">
+  <button class="button" :class="`button--${variant}`">
     <span v-if="!!icon" class="material-icons">{{ icon }}</span>
-    <slot>Button Text</slot>
+    <span class="button__text" :class="{ 'sr-only': variant === 'icon-only' }">
+      <slot>Button Text</slot>
+    </span>
   </button>
 </template>
 <script setup>
-import { computed } from "vue";
-
-const props = defineProps({
+defineProps({
   icon: {
     type: String,
     default: null,
@@ -15,7 +15,9 @@ const props = defineProps({
   variant: {
     type: String,
     validator(str) {
-      return ["primary", "secondary", "inverse", "link"].includes(str);
+      return ["primary", "secondary", "inverse", "link", "icon-only"].includes(
+        str
+      );
     },
     default: "secondary",
   },
@@ -24,13 +26,6 @@ const props = defineProps({
     default: "before",
   },
 });
-
-const classMap = computed(() => ({
-  "button--primary": props.variant === "primary",
-  "button--icon-position-end": props.iconPosition === "end",
-  "button--inverse": props.variant === "inverse",
-  "button--link": props.variant === "link",
-}));
 </script>
 <style scoped>
 .button {
@@ -47,6 +42,17 @@ const classMap = computed(() => ({
   color: var(--black);
   background-color: transparent;
   transition: all ease 0.1s;
+}
+.button--icon-only {
+  padding: 0.5rem;
+  background: var(--black);
+  color: var(--white);
+  border-color: var(--black);
+}
+.button:hover.button--icon-only {
+  background: var(--white);
+  color: var(--black);
+  border-color: var(--white);
 }
 
 .button--icon-position-end {

--- a/src/components/Stage/stages/AR.vue
+++ b/src/components/Stage/stages/AR.vue
@@ -15,6 +15,7 @@
           frameborder="0"
           width="100%"
           height="100%"
+          :allow="`camera ${config.apiBaseUrl}`"
         >
           Loading AR...
         </iframe>

--- a/src/components/Stage/stages/AR.vue
+++ b/src/components/Stage/stages/AR.vue
@@ -1,6 +1,10 @@
 <template>
   <div class="ar-stage">
     <Button icon="travel_explore" @click="toggleShowAr">Look Around</Button>
+    <Alert v-if="!isMobile" icon="info" variant="warning" :dismissable="false">
+      Your device does <b>not</b> fully support Augmented Reality. Things could
+      get weird. 🙃
+    </Alert>
 
     <Teleport to="#modals">
       <div v-if="isShowingAR" class="ar-stage__modal">
@@ -30,6 +34,17 @@
             Simulate Location
           </Toggle>
         </div>
+
+        <Alert
+          v-if="!isMobile"
+          class="ar-stage__modal-alert"
+          icon="info"
+          variant="warning"
+          :dismissable="true"
+        >
+          Your device does <b>not</b> fully support Augmented Reality. Things
+          could get weird. 🙃
+        </Alert>
       </div>
     </Teleport>
   </div>
@@ -42,6 +57,7 @@ import Button from "../../Button/Button.vue";
 import { useStopIndex, useTour } from "../../../common/hooks.js";
 import config from "../../../config.js";
 import Toggle from "../../Toggle/Toggle.vue";
+import Alert from "../../Alert/Alert.vue";
 
 defineProps({
   stage: object().isRequired,
@@ -61,6 +77,12 @@ const src = computed(() => {
   // TODO: change this to use 2 letter locales
   return `${config.apiBaseUrl}/ar/${tour.value.id}/${stopIndex.value}/English/${isSimulatingLocation.value}`;
 });
+
+const isMobile = computed(
+  () =>
+    "ontouchstart" in document.documentElement &&
+    navigator.userAgent.match(/Mobi/)
+);
 </script>
 <style scoped>
 .ar-iframe {
@@ -91,5 +113,10 @@ const src = computed(() => {
   -webkit-backdrop-filter: blur(1rem);
   backdrop-filter: blur(1rem);
   border-radius: 0.25rem;
+}
+.ar-stage__modal-alert {
+  position: absolute;
+  top: 1rem;
+  left: 1rem;
 }
 </style>

--- a/src/components/Stage/stages/AR.vue
+++ b/src/components/Stage/stages/AR.vue
@@ -118,5 +118,8 @@ const isMobile = computed(
   position: absolute;
   top: 1rem;
   left: 1rem;
+  width: 75vw;
+  max-width: 40rem;
+  margin: 0;
 }
 </style>

--- a/src/components/Stage/stages/AR.vue
+++ b/src/components/Stage/stages/AR.vue
@@ -2,16 +2,24 @@
   <div class="ar-stage">
     <Button icon="travel_explore" @click="toggleShowAr">Look Around</Button>
 
-    <iframe
-      v-if="isShowingAR"
-      class="ar-iframe"
-      :src="src"
-      frameborder="0"
-      width="100%"
-      height="100%"
-    >
-      Loading AR...
-    </iframe>
+    <Teleport to="#modals">
+      <Sheet
+        title="Look Around"
+        :isOpen="isShowingAR"
+        @close="isShowingAR = false"
+      >
+        <iframe
+          v-if="isShowingAR"
+          class="ar-iframe"
+          :src="src"
+          frameborder="0"
+          width="100%"
+          height="100%"
+        >
+          Loading AR...
+        </iframe>
+      </Sheet>
+    </Teleport>
   </div>
 </template>
 
@@ -21,6 +29,7 @@ import { bool, object, string } from "vue-types";
 import Button from "../../Button/Button.vue";
 import { useStopIndex, useTour } from "../../../common/hooks.js";
 import config from "../../../config.js";
+import Sheet from "../../Sheet/Sheet.vue";
 
 const props = defineProps({
   stage: object().isRequired,
@@ -33,7 +42,6 @@ const { stopIndex } = useStopIndex();
 
 const isShowingAR = ref(false);
 function toggleShowAr() {
-  console.log("toggleShowAr");
   isShowingAR.value = !isShowingAR.value;
 }
 
@@ -45,7 +53,7 @@ const src = computed(() => {
 <style scope>
 .ar-iframe {
   border: 1px solid #ddd;
-  min-height: 70vh;
-  margin: 1rem 0;
+  height: 70vh;
+  margin: auto;
 }
 </style>

--- a/src/components/Stage/stages/AR.vue
+++ b/src/components/Stage/stages/AR.vue
@@ -15,7 +15,7 @@
           frameborder="0"
           width="100%"
           height="100%"
-          :allow="`camera ${config.apiBaseUrl}`"
+          :allow="`camera ${config.apiBaseUrl}; geolocation; gyroscope; accelerometer; magnetometer; fullscreen`"
         >
           Loading AR...
         </iframe>
@@ -34,7 +34,7 @@ import Sheet from "../../Sheet/Sheet.vue";
 
 const props = defineProps({
   stage: object().isRequired,
-  simulateLocation: bool().def(false),
+  simulateLocation: bool().def(true),
   locale: string().def("en"),
 });
 

--- a/src/components/Stage/stages/AR.vue
+++ b/src/components/Stage/stages/AR.vue
@@ -3,23 +3,25 @@
     <Button icon="travel_explore" @click="toggleShowAr">Look Around</Button>
 
     <Teleport to="#modals">
-      <Sheet
-        title="Look Around"
-        :isOpen="isShowingAR"
-        @close="isShowingAR = false"
-      >
+      <div v-if="isShowingAR" class="ar-stage__modal">
         <iframe
-          v-if="isShowingAR"
           class="ar-iframe"
           :src="src"
           frameborder="0"
           width="100%"
           height="100%"
-          :allow="`camera ${config.apiBaseUrl}; geolocation; gyroscope; accelerometer; magnetometer; fullscreen`"
+          :allow="`camera; geolocation; gyroscope; accelerometer; magnetometer; fullscreen`"
         >
           Loading AR...
         </iframe>
-      </Sheet>
+        <Button
+          class="close-modal-button"
+          icon="close"
+          variant="icon-only"
+          @click="isShowingAR = false"
+          >Close</Button
+        >
+      </div>
     </Teleport>
   </div>
 </template>
@@ -30,7 +32,6 @@ import { bool, object, string } from "vue-types";
 import Button from "../../Button/Button.vue";
 import { useStopIndex, useTour } from "../../../common/hooks.js";
 import config from "../../../config.js";
-import Sheet from "../../Sheet/Sheet.vue";
 
 const props = defineProps({
   stage: object().isRequired,
@@ -51,10 +52,25 @@ const src = computed(() => {
   return `${config.apiBaseUrl}/ar/${tour.value.id}/${stopIndex.value}/English/${props.simulateLocation}`;
 });
 </script>
-<style scope>
+<style scoped>
 .ar-iframe {
-  border: 1px solid #ddd;
-  height: 70vh;
-  margin: auto;
+  height: 100vh;
+  margin: 0;
+  background: var(--gray-lighter);
+}
+
+.ar-stage__modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  /* above navbar */
+  z-index: 200;
+}
+.close-modal-button {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
 }
 </style>

--- a/src/components/Stage/stages/AR.vue
+++ b/src/components/Stage/stages/AR.vue
@@ -21,6 +21,15 @@
           @click="isShowingAR = false"
           >Close</Button
         >
+        <div class="optional-tools">
+          <Toggle
+            :checked="isSimulatingLocation"
+            name="Simulate Location"
+            @change="isSimulatingLocation = !isSimulatingLocation"
+          >
+            Simulate Location
+          </Toggle>
+        </div>
       </div>
     </Teleport>
   </div>
@@ -28,28 +37,29 @@
 
 <script setup>
 import { computed, ref } from "vue";
-import { bool, object, string } from "vue-types";
+import { object, string } from "vue-types";
 import Button from "../../Button/Button.vue";
 import { useStopIndex, useTour } from "../../../common/hooks.js";
 import config from "../../../config.js";
+import Toggle from "../../Toggle/Toggle.vue";
 
-const props = defineProps({
+defineProps({
   stage: object().isRequired,
-  simulateLocation: bool().def(true),
   locale: string().def("en"),
 });
 
+const isSimulatingLocation = ref(false);
 const { tour } = useTour();
 const { stopIndex } = useStopIndex();
-
 const isShowingAR = ref(false);
+
 function toggleShowAr() {
   isShowingAR.value = !isShowingAR.value;
 }
 
 const src = computed(() => {
   // TODO: change this to use 2 letter locales
-  return `${config.apiBaseUrl}/ar/${tour.value.id}/${stopIndex.value}/English/${props.simulateLocation}`;
+  return `${config.apiBaseUrl}/ar/${tour.value.id}/${stopIndex.value}/English/${isSimulatingLocation.value}`;
 });
 </script>
 <style scoped>
@@ -72,5 +82,14 @@ const src = computed(() => {
   position: absolute;
   top: 1rem;
   right: 1rem;
+}
+.optional-tools {
+  position: absolute;
+  bottom: 1rem;
+  right: 1rem;
+  background: rgb(255 255 255/ 0.5);
+  -webkit-backdrop-filter: blur(1rem);
+  backdrop-filter: blur(1rem);
+  border-radius: 0.25rem;
 }
 </style>

--- a/src/components/Toggle/Toggle.vue
+++ b/src/components/Toggle/Toggle.vue
@@ -1,0 +1,122 @@
+<template>
+  <div class="toggle" @drag="console.log('drag')">
+    <input
+      :id="name"
+      class="toggle__input sr-only"
+      type="checkbox"
+      :checked="checked"
+      :name="name"
+      @change="handleInputChange($event)"
+      @drag="console.log('drag')"
+    />
+    <label class="toggle__label" :for="name">
+      <span class="toggle__label-text">
+        <slot />
+      </span>
+    </label>
+  </div>
+</template>
+
+<script setup>
+defineProps({
+  checked: {
+    type: Boolean,
+    required: true,
+  },
+  name: {
+    type: String,
+    required: true,
+  },
+  color: {
+    type: String,
+  },
+});
+
+const emit = defineEmits(["change"]);
+
+function handleInputChange(event) {
+  emit("change", event);
+}
+</script>
+
+<style scoped>
+.toggle {
+  --height: 1.5rem;
+  --width: 3rem;
+  --color: var(--black);
+  --padding: 0.8rem;
+  padding: var(--padding);
+  position: relative;
+  user-select: none;
+  width: calc(var(--width) + 2 * var(--padding));
+}
+.toggle__label {
+  position: relative;
+  padding-top: var(--height);
+  display: block;
+  text-align: center;
+  cursor: pointer;
+  width: 100%;
+}
+
+/* toggle outline and bg */
+.toggle__label::before {
+  content: "";
+  display: block;
+  border: 1px solid var(--gray-300);
+  height: var(--height);
+  width: var(--width);
+  border-radius: calc(var(--height) / 2);
+  position: absolute;
+  top: 0;
+  background: var(--gray-300);
+  /* center it */
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+/* outline and bg when checked */
+.toggle__input:checked ~ .toggle__label::before {
+  background: var(--system-green);
+  border-color: #9de1b9;
+}
+
+/* toggle circle */
+.toggle__label::after {
+  --circle-diameter: calc(var(--height) - 4px);
+  content: "";
+  display: block;
+  width: var(--circle-diameter);
+  height: var(--circle-diameter);
+  border-radius: 50%;
+  background: var(--white);
+  position: absolute;
+  top: 2px;
+  left: 50%;
+  /* center, then shift to left (off state), the nudge 2px */
+  transform-origin: center;
+  transform: translateX(calc(-1 * var(--width) / 2 + 2px));
+  transition: 0.2s;
+  box-shadow: 0 1px 10px rgb(0 0 0 / 0.25);
+}
+/* circle when checked */
+.toggle__input:checked ~ .toggle__label::after {
+  --translation: calc(var(--width) / 2 - var(--circle-diameter) - 2px);
+  transform: translateX(var(--translation));
+}
+
+/* label text */
+.toggle__label-text {
+  display: block;
+  font-size: 0.75rem;
+  margin-top: 0.4rem;
+  color: var(--color);
+  text-align: center;
+  max-width: 100%;
+  word-wrap: normal;
+}
+
+/* label text when checked */
+.toggle__input:checked ~ .toggle__label .toggle__label-text {
+}
+</style>

--- a/src/main.css
+++ b/src/main.css
@@ -41,6 +41,7 @@ html {
   --orange: var(--orange-medium);
   --system-blue: #0a84ff;
   --system-red: #ff453a;
+  --system-green: #00c853;
   --translucent-color: hsla(0, 0%, 100%, 0.75);
   --translucent-filter: blur(0.25rem);
 


### PR DESCRIPTION
- Changes AR embed to full screen AR.
- fixes permissions issues on mobile devices
- adds a simulate location toggle for when users want to pretend they're someplace else, like in the french quarter eating poboys or something.

Closes #5